### PR TITLE
Add github workflow for generating pdf

### DIFF
--- a/.github/workflows/convert-to-pdf.yml
+++ b/.github/workflows/convert-to-pdf.yml
@@ -1,0 +1,24 @@
+name: README to PDF
+# This workflow is triggered on pushes to the repository.
+on:
+  push:
+    branches:
+      - main
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  converttopdf:
+    name: Build PDF
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: baileyjm02/markdown-to-pdf@v1
+        with:
+          input_dir: 
+          output_dir: 
+          build_html: false
+          table_of_contents: true
+      - uses: actions/upload-artifact@v2
+


### PR DESCRIPTION
Github workflow for generating PDF file from README file automatically when pushes to main.
After merging this PR, please follow [this guide](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) if you want to change organization settings for workflows.