### PR TITLE
Community link is fixed DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Before you head over, read the [Contribution Guide](CONTRIBUTING.md) first. You 
 - ### DevOps
 
   - **Community**
-    - [DevOps, SRE, & Infrastructure](https://discord.gg/devops)
+    - [DevOps, SRE, & Infrastructure](https://discord.com/invite/VEEnHkPzY6)
 
   - **CI/CD**
     - [CI/CD Full Course | Continuous Integration And Continuous](https://www.youtube.com/watch?v=h9K1NnqwUvE)


### PR DESCRIPTION
After reading the contribution guide, I have fixed the community link in the DevOps section. This [issue](https://github.com/DjangoEx/python-engineer-roadmap/issues/128) was already reported.
I have opened this PR. Please review this PR. 
Thanks

<img width="240" alt="image" src="https://user-images.githubusercontent.com/24452313/191074607-5c0a51d1-5334-4cd6-95a8-3d239708506b.png">