### PR TITLE
Added link of Python Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Before you head over, read the [Contribution Guide](CONTRIBUTING.md) first. You 
   - **Cheat Sheet**
     - [Beginners Python cheat sheet](https://edu.anarcho-copy.org/Programming%20Languages/Python/Python%20CheatSheet/beginners_python_cheat_sheet_pcc_django.pdf)
     - [Python cheat sheet](https://perso.limsi.fr/pointal/_media/python:cours:mementopython3-english.pdf)
+    - [Python Developer Roadmap](https://roadmap.sh/python)
   
 ## Career Path
 


### PR DESCRIPTION
Hi @bobycloud,

I came across your repository [python-engineer-roadmap](https://github.com/DjangoEx/python-engineer-roadmap) and found it to be a valuable resource for Python enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Python Developer Roadmap"](https://roadmap.sh/python). I took the initiative to submit a ["Pull Request"](https://github.com/DjangoEx/python-engineer-roadmap/pull/139) adding it in "Python > Cheat Sheet" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz